### PR TITLE
feat(provider): upgrade for provider version 0.8.2

### DIFF
--- a/application/service/upgrade_service.py
+++ b/application/service/upgrade_service.py
@@ -263,7 +263,7 @@ class UpgradeService:
 
             # Backup existing values
             log.info("Backing up helm values...")
-            backup_cmd = "cd /root/provider && for i in $(helm list -n akash-services -q | grep -vw akash-node); do helm -n akash-services get values $i > ${i}.pre-v0.6.10.values; done"
+            backup_cmd = "cd /root/provider && for i in $(helm list -n akash-services -q | grep -vw akash-node); do helm -n akash-services get values $i > ${i}.pre-v0.8.2.values; done"
             run_ssh_command(ssh_client, backup_cmd, True, task_id=task_id)
 
             # Upgrade hostname operator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup naming for Helm values during upgrades to use the .pre-v0.8.2.values suffix instead of .pre-v0.6.10.values. This improves clarity and version traceability for generated backups without changing the upgrade flow.
  * Existing backups are unaffected and remain accessible. No user action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->