### PR TITLE
new version of calico

### DIFF
--- a/application/service/k3s_service.py
+++ b/application/service/k3s_service.py
@@ -235,7 +235,7 @@ EOF
         try:
             log.info("Installing Calico CNI...")
             commands = [
-                "curl -O https://raw.githubusercontent.com/projectcalico/calico/refs/tags/v3.28.2/manifests/calico.yaml",
+                "curl -O https://raw.githubusercontent.com/projectcalico/calico/refs/tags/v3.29.3/manifests/calico.yaml",
                 'yq eval-all \'(select(.kind == "DaemonSet" and .metadata.name == "calico-node").spec.template.spec.containers[] | select(.name == "calico-node").env) += {"name": "IP_AUTODETECTION_METHOD", "value": "kubernetes-internal-ip"}\' -i calico.yaml',
                 "kubectl apply -f calico.yaml",
             ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - None.

- Chores
  - Updated Calico CNI to v3.29.3 for k3s installations. New and re-provisioned clusters will use the newer networking plugin automatically. No configuration changes required. This update brings upstream fixes and improvements for greater stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->