### PR TITLE
Update provider-services to v0.11.1 and helm chart versions

### DIFF
--- a/application/config/config.py
+++ b/application/config/config.py
@@ -25,17 +25,17 @@ class Config:
         "https://raw.githubusercontent.com/akash-network/provider-configs/main/devices/pcie/gpus.json",
     )
     KEYRING_BACKEND = environ.get("KEYRING_BACKEND", "file")
-    AKASH_VERSION = environ.get("AKASH_VERSION", "v1.0.0")
+    AKASH_VERSION = environ.get("AKASH_VERSION", "v2.0.1")
     AKASH_NODE_HELM_CHART_VERSION = environ.get(
-        "AKASH_NODE_HELM_CHART_VERSION", "14.0.0"
+        "AKASH_NODE_HELM_CHART_VERSION", "17.0.0"
     )
     INGRESS_NGINX_VERSION = environ.get("INGRESS_NGINX_VERSION", "4.11.3")
-    PROVIDER_SERVICES_VERSION = environ.get("PROVIDER_SERVICES_VERSION", "v0.10.1")
+    PROVIDER_SERVICES_VERSION = environ.get("PROVIDER_SERVICES_VERSION", "v0.11.1")
     PROVIDER_SERVICES_HELM_CHART_VERSION = environ.get(
-        "PROVIDER_SERVICES_HELM_CHART_VERSION", "14.0.3"
+        "PROVIDER_SERVICES_HELM_CHART_VERSION", "15.0.1"
     )
-    PROVIDER_HOSTNAME_OPERATOR_VERSION = environ.get("PROVIDER_HOSTNAME_OPERATOR_VERSION", "v0.10.0")
-    PROVIDER_INVENTORY_OPERATOR_VERSION = environ.get("PROVIDER_INVENTORY_OPERATOR_VERSION", "v0.10.0")
+    PROVIDER_HOSTNAME_OPERATOR_VERSION = environ.get("PROVIDER_HOSTNAME_OPERATOR_VERSION", "v0.11.1")
+    PROVIDER_INVENTORY_OPERATOR_VERSION = environ.get("PROVIDER_INVENTORY_OPERATOR_VERSION", "v0.11.1")
     PROVIDER_PRICE_SCRIPT_URL = environ.get(
         "PROVIDER_PRICE_SCRIPT_URL",
         "https://raw.githubusercontent.com/akash-network/helm-charts/main/charts/akash-provider/scripts/price_script_generic.sh",


### PR DESCRIPTION
Bumps default version values to match the v0.11.1 release:
- AKASH_VERSION: v1.0.0 -> v2.0.1
- AKASH_NODE_HELM_CHART_VERSION: 14.0.0 -> 17.0.0
- PROVIDER_SERVICES_VERSION: v0.10.1 -> v0.11.1
- PROVIDER_SERVICES_HELM_CHART_VERSION: 14.0.3 -> 15.0.1
- PROVIDER_HOSTNAME_OPERATOR_VERSION: v0.10.0 -> v0.11.1
- PROVIDER_INVENTORY_OPERATOR_VERSION: v0.10.0 -> v0.11.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default component versions including Akash core engine (v1.0.0 → v2.0.1), Helm chart deployments, Provider Services (v0.10.1 → v0.11.1), and operator versions (v0.10.0 → v0.11.1) for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->