### PR TITLE
fix: raise provider-services install timeout to 60s

### DIFF
--- a/application/service/wallet_service.py
+++ b/application/service/wallet_service.py
@@ -230,19 +230,17 @@ class WalletService:
             # Install unzip dependency
             run_ssh_command(self.ssh_client, "apt-get install -y unzip")
 
-            # Install provider-services with timeout (15s requires minimum ~10 Mbps connection)
-            install_command = f"timeout 15 bash -c 'curl -sfL https://raw.githubusercontent.com/akash-network/provider/main/install.sh | bash -s -- {Config.PROVIDER_SERVICES_VERSION}'"
+            install_command = f"timeout 60 bash -c 'curl -sfL https://raw.githubusercontent.com/akash-network/provider/main/install.sh | bash -s -- {Config.PROVIDER_SERVICES_VERSION}'"
             try:
                 run_ssh_command(self.ssh_client, install_command)
             except ApplicationError as e:
-                # timeout command returns exit code 124 when it kills the process
                 if e.payload.get("exit_code") == 124:
                     raise ApplicationError(
                         status_code=status.HTTP_504_GATEWAY_TIMEOUT,
                         error_code="WAL_007",
                         payload={
                             "error": "Provider Services Installation Timeout",
-                            "message": "Installation timed out. Your network connection is too slow. A minimum of 10 Mbps is required.",
+                            "message": "Provider-services download did not complete within 60 seconds. Check the target host's network connectivity to GitHub and retry.",
                         },
                     )
                 raise


### PR DESCRIPTION
## Summary
- `_install_and_verify_provider_services` wrapped the `curl install.sh | bash` pipeline in `timeout 15`, which consistently fails for the v0.12.0 binary on real-world links — observed during staging testing (provider-services exit 124 after ~16s).
- Bumps the wall-clock timeout to 60s and rewrites the user-facing error so it no longer promises "10 Mbps required" (the original math never held: a ~40–60 MB binary on a 10 Mbps link needs 30–50s for the download alone, before TLS/redirects/apt steps).

## Test plan
- [ ] Run a full provider build against staging and confirm provider-services installs without `WAL_007`.
- [ ] Force a slow link (e.g. `tc qdisc` or a constrained VM) and confirm the new error message fires cleanly past 60s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased provider service installation timeout tolerance to improve reliability on slower network connections. Updated error messaging to better indicate network connectivity issues during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/provider-console-api/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->