### PR TITLE
fix: install Gateway API CRDs before akash-services helm install

### DIFF
--- a/application/service/akash_cluster_service.py
+++ b/application/service/akash_cluster_service.py
@@ -245,6 +245,13 @@ class AkashClusterService:
             ),
             Task(
                 str(uuid4()),
+                "install_gateway_api_crds",
+                "Install Gateway API CRDs",
+                self.gateway_api_service.install_gateway_api_crds,
+                ssh_client,
+            ),
+            Task(
+                str(uuid4()),
                 "install_akash_services",
                 "Install Akash services",
                 self.provider_service._install_akash_services,
@@ -283,13 +290,6 @@ class AkashClusterService:
                 self.provider_service._install_akash_provider,
                 ssh_client,
                 provider_version,
-            ),
-            Task(
-                str(uuid4()),
-                "install_gateway_api_crds",
-                "Install Gateway API CRDs",
-                self.gateway_api_service.install_gateway_api_crds,
-                ssh_client,
             ),
             Task(
                 str(uuid4()),


### PR DESCRIPTION
## Summary
- Fresh-cluster builds fail at `install_akash_services` with `no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1"` because the `akash-hostname-operator` chart (provider v0.12.0) now ships an HTTPRoute resource, but the Gateway API CRDs were installed several tasks later in `_create_provider_tasks`.
- Move `install_gateway_api_crds` immediately after `setup_helm_repos`, ahead of `install_akash_services`. The Gateway API migration path (`migrate_gateway_api`) already installs CRDs first, which is why v0.11→v0.12 upgrades worked but greenfield cluster builds did not.

## Error this fixes
```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest:
resource mapping not found for name: "akash-hostname-operator" namespace: "akash-services"
from "": no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1"
ensure CRDs are installed first
```

## Test plan
- [ ] Trigger a fresh cluster build via `create_akash_cluster` against a mainnet target and confirm `install_akash_services` succeeds.
- [ ] Trigger a fresh cluster build against a sandbox/dev target (`akash-dev` repo + `--devel`) and confirm the same.
- [ ] Re-run an existing v0.11→v0.12 migration via `migrate_gateway_api` to confirm no regression (CRDs are still applied server-side and idempotent).
- [ ] Confirm subsequent tasks (`install_nginx_gateway_fabric`, `install_cert_manager`, `install_akash_gateway`, `rollout_restart_ngf`) still succeed in the new order.