### PR TITLE
fix: pass ACME email to akash-provider chart on fresh install

### DIFF
--- a/application/service/akash_cluster_service.py
+++ b/application/service/akash_cluster_service.py
@@ -290,6 +290,7 @@ class AkashClusterService:
                 self.provider_service._install_akash_provider,
                 ssh_client,
                 provider_version,
+                cert_manager_input.acme_email,
             ),
             Task(
                 str(uuid4()),

--- a/application/service/provider_service.py
+++ b/application/service/provider_service.py
@@ -578,9 +578,12 @@ helm upgrade -i nvdp nvdp/nvidia-device-plugin \
             helm_repo = "akash" if Config.CHAIN_ID == "akashnet-2" else "akash-dev"
             devel_flag = "" if Config.CHAIN_ID == "akashnet-2" else "--devel"
             
-            # Build helm upgrade command with consistent parameters
+            # Build helm upgrade command with consistent parameters.
+            # --reuse-values keeps install-time --set overrides (notably
+            # letsEncrypt.acme.email) intact; -f and --set below still
+            # layer on top.
             command = (
-                f'helm upgrade --install akash-provider {helm_repo}/provider '
+                f'helm upgrade --install --reuse-values akash-provider {helm_repo}/provider '
                 f'-n akash-services -f ~/provider/provider.yaml '
                 f'--set bidpricescript="{pricing_script_b64}" '
                 f'--set image.tag={provider_version} {devel_flag}'

--- a/application/service/provider_service.py
+++ b/application/service/provider_service.py
@@ -148,7 +148,9 @@ EOF
         )
         log.info("Akash provider CRDs installed.")
 
-    def _install_akash_provider(self, ssh_client, provider_version, task_id: str):
+    def _install_akash_provider(
+        self, ssh_client, provider_version, acme_email, task_id: str
+    ):
         log.info("Installing Akash provider...")
         time.sleep(5)
         try:
@@ -164,11 +166,12 @@ EOF
             # Determine helm repo and flags based on chain ID
             helm_repo = "akash" if Config.CHAIN_ID == "akashnet-2" else "akash-dev"
             devel_flag = "" if Config.CHAIN_ID == "akashnet-2" else "--devel"
-            
+
             install_cmd = (
                 f"helm install akash-provider {helm_repo}/provider "
                 f"-n akash-services -f ~/provider/provider.yaml "
-                f"--set image.tag={provider_version} {devel_flag}".strip()
+                f"--set image.tag={provider_version} "
+                f"--set letsEncrypt.acme.email={acme_email} {devel_flag}".strip()
             )
 
             if pricing_script_b64:


### PR DESCRIPTION
## Summary
- Fresh-install path can leave the akash-provider pod crashlooping with `Error: cert issuer: invalid config: invalid email`.
- Root cause: the akash-provider chart's `letsencrypt-configmap` reads `AP_CERT_ISSUER_EMAIL` from `.Values.letsEncrypt.acme.email` and falls back to `.Values.email` (the top-level `email:` in `~/provider/provider.yaml`). `ProviderBuildInput` only requires *one of* `provider.config.email` or `cert_manager.acme_email`, so a user who only fills in the cert-manager email ends up with both chart values empty and the env var never emitted. The entrypoint then omits `--cert-issuer-email`, and the provider rejects the config.
- Fix: pass `cert_manager.acme_email` (a validated `EmailStr`, guaranteed present by the build-input validator) into `_install_akash_provider` and add `--set letsEncrypt.acme.email=<acme_email>` to the helm install. The chart now always receives an email regardless of what's in `provider.yaml`.

## Why migration isn't affected
The Gateway API migration path upgrades the chart against the existing `~/provider/provider.yaml`, which on a v0.11.x cluster always carries a populated top-level `email:`. The chart's `.Values.email` fallback picks that up, so `AP_CERT_ISSUER_EMAIL` is rendered correctly during upgrade.

## Test plan
- [ ] Fresh `create_akash_cluster` against mainnet with **only** `cert_manager.acme_email` filled (no `provider.config.email`): confirm `akash-provider-0` starts, entrypoint debug shows `AP_CERT_ISSUER_EMAIL: <user-email>`, and final command includes `--cert-issuer-email=<user-email>`.
- [ ] Fresh build against mainnet with both emails set: confirm `letsEncrypt.acme.email` (cert-manager input) is what reaches the pod.
- [ ] Fresh build against sandbox (`akash-dev` + `--devel`): same checks.
- [ ] `migrate_gateway_api` on an existing v0.11.x cluster: confirm provider still starts cleanly (no change expected — chart falls back to `.Values.email` from the existing provider.yaml).
- [ ] `kubectl -n akash-services get cm akash-provider-letsencrypt -o yaml` shows the email in `AP_CERT_ISSUER_EMAIL` after install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Provider installation workflow now supports ACME email configuration. Users can specify an email address during provider setup for certificate integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/provider-console-api/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->