### PR TITLE
fix: preserve ACME email on provider chart upgrade via --reuse-values

### DIFF
--- a/application/service/upgrade_service.py
+++ b/application/service/upgrade_service.py
@@ -348,13 +348,16 @@ class UpgradeService:
 
             # Upgrade provider chart
             log.info("Upgrading provider chart...")
+            # --reuse-values keeps install-time --set overrides (notably
+            # letsEncrypt.acme.email) intact across upgrades; -f and --set
+            # below still layer on top.
             if Config.CHAIN_ID == "akashnet-2":
                 provider_upgrade_cmd = (
-                    f"helm upgrade akash-provider akash/provider -n akash-services -f ~/provider/provider.yaml --set bidpricescript=\"$(cat ~/provider/price_script_generic.sh | openssl base64 -A)\" --set image.tag={app_version}"
+                    f"helm upgrade --reuse-values akash-provider akash/provider -n akash-services -f ~/provider/provider.yaml --set bidpricescript=\"$(cat ~/provider/price_script_generic.sh | openssl base64 -A)\" --set image.tag={app_version}"
                 )
             else:
                 provider_upgrade_cmd = (
-                    f"helm upgrade akash-provider akash-dev/provider -n akash-services -f ~/provider/provider.yaml --set bidpricescript=\"$(cat ~/provider/price_script_generic.sh | openssl base64 -A)\" --set image.tag={app_version} --devel"
+                    f"helm upgrade --reuse-values akash-provider akash-dev/provider -n akash-services -f ~/provider/provider.yaml --set bidpricescript=\"$(cat ~/provider/price_script_generic.sh | openssl base64 -A)\" --set image.tag={app_version} --devel"
                 )
             run_ssh_command(ssh_client, provider_upgrade_cmd, True, task_id=task_id)
 


### PR DESCRIPTION
## Summary
- Follow-up to #69. `upgrade_service.py` runs `helm upgrade akash-provider` without `--reuse-values`, so unspecified values reset to chart defaults each upgrade.
- For operators who only supplied `cert_manager.acme_email` on install (no top-level `email:` in `provider.yaml`), this wipes `letsEncrypt.acme.email` and the provider pod crashes after upgrade with `Error: cert issuer: invalid config: invalid email` — the same failure mode #69 fixed for the restart path.
- Apply `--reuse-values` to both upgrade paths (`akashnet-2` and sandbox/`--devel`). `-f provider.yaml` and the explicit `--set` overrides (`bidpricescript`, `image.tag`) still layer on top.

## Test plan
- [ ] On a v0.12.0 cluster that was fresh-installed with only `cert_manager.acme_email` (no `provider.config.email`): run `upgrade_provider`, confirm `akash-provider-0` restarts cleanly and the entrypoint debug shows the original `AP_CERT_ISSUER_EMAIL` value preserved.
- [ ] On a cluster that has `provider.config.email` populated: run `upgrade_provider`, confirm no regression in `image.tag` or `bidpricescript` (both should still update to the new values via the explicit `--set` flags layered over the reused values).
- [ ] Run `upgrade_network` on a sandbox cluster: same checks on the `--devel` path.
- [ ] `kubectl -n akash-services get cm akash-provider-letsencrypt -o yaml` shows `AP_CERT_ISSUER_EMAIL` still set after upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider Helm chart upgrades now preserve previously configured values during the upgrade process. This ensures settings established at installation time (such as email configuration) are retained rather than being reset during upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/provider-console-api/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->